### PR TITLE
fix(ci): replace missing uv GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/uv-action@v1
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
@@ -50,7 +50,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/uv-action@v1
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11"
       - name: Publish package


### PR DESCRIPTION
## Summary
- use `astral-sh/setup-uv@v6` instead of the missing `uv-action`

## Testing
- `uv sync --dev`
- `uv run ruff check --no-fix .`
- `uv run mypy meta_tags_parser`
- `uv build`
- `uv run pytest -n2 . --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_689d2832e85083258cb9bfb8806ffd7a