### PR TITLE
ci: give coverage artifacts unique names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - run: uv run pytest -n2 . --cov-report=xml
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python-version }}
           path: ./coverage.xml
 
   upload-codecov:
@@ -38,11 +38,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-*
+          path: .
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          files: coverage-*/coverage.xml
 
   publish-pypi:
     needs: upload-codecov


### PR DESCRIPTION
## Summary
- avoid upload-artifact conflicts in matrix builds by naming coverage artifacts per Python version
- download all coverage artifacts for Codecov

## Testing
- `uv run ruff check --no-fix .`
- `uv run mypy meta_tags_parser`
- `uv run pytest -n2 . --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_689d2edb369c8325955cc3e0cd255f75