### PR TITLE
feat: add coverage badge generation

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "coverage", "message": "100%", "color": "#2A9D8F"}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,52 +9,55 @@ on:
       - bugfix/**
     tags:
       - "*"
+    paths-ignore:
+      - .github/badges/**
+
+env:
+  PYTHON_LATEST: "3.13"
+  PYTHON_OLD_VERSIONS: '["3.9", "3.10", "3.11", "3.12"]'
 
 jobs:
-  run-tests-and-coverage:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{ fromJson(env.PYTHON_OLD_VERSIONS) }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
-      - run: uv run ruff check --no-fix .
-      - run: uv run mypy meta_tags_parser
-      - run: uv build
-      - run: uv run pytest -n2 . --cov-report=xml
-      - uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.python-version }}
-          path: ./coverage.xml
+      - run: uv run pytest -n2 .
 
-  upload-codecov:
+  coverage-badge:
     runs-on: ubuntu-latest
-    needs: run-tests-and-coverage
+    needs: tests
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: astral-sh/setup-uv@v6
         with:
-          pattern: coverage-*
-          path: .
-      - uses: codecov/codecov-action@v4
+          python-version: ${{ env.PYTHON_LATEST }}
+      - run: uv sync --dev
+      - run: uv run ruff check --no-fix .
+      - run: uv run mypy meta_tags_parser scripts
+      - run: uv build
+      - run: uv run pytest -n2 . --cov-report=xml
+      - run: uv run python scripts/generate_coverage_badge.py
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          files: coverage-*/coverage.xml
+          commit_message: 'docs: update coverage badge'
+          file_pattern: .github/badges/coverage.json
 
   publish-pypi:
-    needs: upload-codecov
+    needs: coverage-badge
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_LATEST }}
       - name: Publish package
         continue-on-error: true
         run: |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Test, lint, publish](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml/badge.svg)](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml)
 [![PyPI version](https://badge.fury.io/py/meta-tags-parser.svg)](https://badge.fury.io/py/meta-tags-parser)
 [![Downloads](https://pepy.tech/badge/meta-tags-parser)](https://pepy.tech/project/meta-tags-parser)
-[![codecov](https://codecov.io/gh/xfenix/meta-tags-parser/branch/master/graph/badge.svg)](https://codecov.io/gh/xfenix/meta-tags-parser)
+![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xfenix/meta-tags-parser/master/.github/badges/coverage.json)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 [![Imports: isort](https://img.shields.io/badge/imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://timothycrosley.github.io/isort/)
 

--- a/scripts/generate_coverage_badge.py
+++ b/scripts/generate_coverage_badge.py
@@ -1,0 +1,43 @@
+import json
+import types
+import typing
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+COVERAGE_XML_PATH: typing.Final = Path("coverage.xml")
+BADGE_JSON_PATH: typing.Final = Path(".github/badges/coverage.json")
+LOW_BOUNDARY: typing.Final[float] = 60
+HIGH_BOUNDARY: typing.Final[float] = 80
+
+
+def build_badge_file() -> None:
+    xml_source_text: typing.Final[str] = COVERAGE_XML_PATH.read_text()
+    root_element: typing.Final[ET.Element] = ET.fromstring(xml_source_text)  # noqa: S314
+    line_rate_text: typing.Final[str] = root_element.attrib["line-rate"]
+    coverage_percent: typing.Final[float] = float(line_rate_text) * 100.0
+
+    message_text: typing.Final[str] = f"{coverage_percent:.0f}%"
+    color_text: str
+    if coverage_percent < LOW_BOUNDARY:
+        color_text = "#E63946"
+    elif coverage_percent < HIGH_BOUNDARY:
+        color_text = "#FFB347"
+    else:
+        color_text = "#2A9D8F"
+
+    badge_mapping: typing.Final[typing.Mapping[str, typing.Any]] = types.MappingProxyType(
+        {
+            "schemaVersion": 1,
+            "label": "coverage",
+            "message": message_text,
+            "color": color_text,
+        },
+    )
+
+    BADGE_JSON_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BADGE_JSON_PATH.write_text(json.dumps(dict(badge_mapping)))
+
+
+if __name__ == "__main__":
+    build_badge_file()


### PR DESCRIPTION
## Summary
- remove Codecov integration from CI
- add script to build Shields.io coverage badge JSON
- publish generated badge link in README
- run coverage badge generation in dedicated job instead of matrix conditional
- use variables to define Python 3.13 as default and test matrix for 3.9–3.12

## Testing
- `uv run ruff check --no-fix .`
- `uv run mypy meta_tags_parser scripts`
- `uv run pytest -n2 . --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68a0890abcd0832589f7dea6a133defc