### PR TITLE
fix: run tests across python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,17 @@ on:
 
 env:
   PYTHON_LATEST: "3.13"
-  PYTHON_OLD_VERSIONS: '["3.9", "3.10", "3.11", "3.12"]'
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ fromJson(env.PYTHON_OLD_VERSIONS) }}
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## Summary
- fix GitHub Actions matrix resolution by inlining Python versions

## Testing
- `uv run ruff check --no-fix .`
- `uv run mypy meta_tags_parser scripts`
- `uv run pytest -n2 .`


------
https://chatgpt.com/codex/tasks/task_e_68a1fdbd51248325a94cf1e42d02b5cf