### PR TITLE
docs: link coverage badge to pytest summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Test, lint, publish](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml/badge.svg)](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml)
 [![PyPI version](https://badge.fury.io/py/meta-tags-parser.svg)](https://badge.fury.io/py/meta-tags-parser)
 [![Downloads](https://pepy.tech/badge/meta-tags-parser)](https://pepy.tech/project/meta-tags-parser)
-![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xfenix/meta-tags-parser/master/.github/badges/coverage.json)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xfenix/meta-tags-parser/master/.github/badges/coverage.json)](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 [![Imports: isort](https://img.shields.io/badge/imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://timothycrosley.github.io/isort/)
 


### PR DESCRIPTION
## Summary
- link coverage badge to the test workflow so it opens pytest summary

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a20c9e833c8325825f2464b70bd4dd