### PR TITLE
ci: publish coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
       - "*"
     paths-ignore:
       - .github/badges/**
+      - .github/coverage/**
 
 env:
   PYTHON_LATEST: "3.13"
@@ -36,6 +37,10 @@ jobs:
   coverage-badge:
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -45,12 +50,16 @@ jobs:
       - run: uv run ruff check --no-fix .
       - run: uv run mypy meta_tags_parser scripts
       - run: uv build
-      - run: uv run pytest -n2 . --cov-report=xml
+      - run: uv run pytest -n2 . --cov-report=xml --cov-report=html
       - run: uv run python scripts/generate_coverage_badge.py
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'docs: update coverage badge'
           file_pattern: .github/badges/coverage.json
+      - run: mv htmlcov coverage
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: coverage
 
   publish-pypi:
     needs: coverage-badge
@@ -67,3 +76,16 @@ jobs:
           uv version "${GITHUB_REF_NAME#v}"
           uv build
           uv publish --username "${{ secrets.PYPI_USERNAME }}" --password "${{ secrets.PYPI_PASSWORD }}"
+
+  deploy-coverage:
+    needs: coverage-badge
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.github/coverage/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Test, lint, publish](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml/badge.svg)](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml)
 [![PyPI version](https://badge.fury.io/py/meta-tags-parser.svg)](https://badge.fury.io/py/meta-tags-parser)
 [![Downloads](https://pepy.tech/badge/meta-tags-parser)](https://pepy.tech/project/meta-tags-parser)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xfenix/meta-tags-parser/master/.github/badges/coverage.json)](https://github.com/xfenix/meta-tags-parser/actions/workflows/main.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xfenix/meta-tags-parser/master/.github/badges/coverage.json)](https://xfenix.github.io/meta-tags-parser/coverage/index.html)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 [![Imports: isort](https://img.shields.io/badge/imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://timothycrosley.github.io/isort/)
 


### PR DESCRIPTION
## Summary
- generate HTML coverage report in CI and publish it to GitHub Pages
- point coverage badge to published report
- ignore generated coverage directory

## Testing
- `uv run ruff check .`
- `uv run mypy meta_tags_parser scripts`
- `uv run pytest -n2 . --cov-report=xml --cov-report=html`


------
https://chatgpt.com/codex/tasks/task_e_68a212e56be4832584392c25583b1c0e