### PR TITLE
ci: verify package installability before publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           uv version "${GITHUB_REF_NAME#v}"
           uv build
+          uv pip install dist/*.whl
           uv publish --username "${{ secrets.PYPI_USERNAME }}" --password "${{ secrets.PYPI_PASSWORD }}"
 
   deploy-coverage:


### PR DESCRIPTION
## Summary
- ensure publish job installs built wheel before uploading to PyPI

## Testing
- `uv run ruff check --no-fix .`
- `uv run mypy meta_tags_parser scripts`
- `uv run pytest -n2 .`


------
https://chatgpt.com/codex/tasks/task_e_68a23600ba148325b858a3831d226630