### PR TITLE
refactor snippet parsing

### DIFF
--- a/meta_tags_parser/snippets.py
+++ b/meta_tags_parser/snippets.py
@@ -1,27 +1,44 @@
 """Snippets helper functions."""
-from .parse import parse_meta_tags_from_source, settings, structs
+import dataclasses
+import typing
+
+from . import structs
+from .parse import parse_meta_tags_from_source
+
+
+SNIPPET_META_TAGS: typing.Final[tuple[str, ...]] = (
+    "title",
+    "description",
+    "url",
+    "image",
+    "image:width",
+    "image:height",
+)
 
 
 def parse_snippets_from_source(source_code: str) -> structs.SnippetGroup:
-    """Parse snippets from source code.
-
-    This function use «ugly» magic like getattr, setattr.
-    This is sad, but i don't find at the bottom of my mind a better solution at the moment.
-    If you have a more reasonable solution — feel free to push me, I will be grateful for any advice.
-    """
-    parsed_data: structs.TagsGroup = parse_meta_tags_from_source(
+    """Parse snippets from source code."""
+    parsed_group: structs.TagsGroup = parse_meta_tags_from_source(
         source_code, (structs.WhatToParse.OPEN_GRAPH, structs.WhatToParse.TWITTER)
     )
-    prepared_result: structs.SnippetGroup = structs.SnippetGroup()
-    sm_group: str
-    one_tag: structs.OneMetaTag
-    for sm_group in ("twitter", "open_graph"):
-        new_snippet: structs.SocialMediaSnippet = structs.SocialMediaSnippet()
-        for one_tag in getattr(parsed_data, sm_group):
-            if one_tag.name in settings.SOCIAL_MEDIA_SNIPPET_WHAT_ATTRS_TO_COPY:
-                setattr(new_snippet, one_tag.name.replace(":", "_"), one_tag.value)
-        setattr(prepared_result, sm_group, new_snippet)
-    return prepared_result
+    result_group: structs.SnippetGroup = structs.SnippetGroup()
+    social_name: str
+    parsed_tags: list[structs.OneMetaTag]
+    for social_name, parsed_tags in (
+        ("twitter", parsed_group.twitter),
+        ("open_graph", parsed_group.open_graph),
+    ):
+        snippet_fields: dict[str, str] = {}
+        meta_tag: structs.OneMetaTag
+        for meta_tag in parsed_tags:
+            if meta_tag.name in SNIPPET_META_TAGS:
+                snippet_fields[meta_tag.name.replace(":", "_")] = meta_tag.value
+        snippet_object = structs.SocialMediaSnippet(**snippet_fields)
+        if social_name == "twitter":
+            result_group = dataclasses.replace(result_group, twitter=snippet_object)
+        else:
+            result_group = dataclasses.replace(result_group, open_graph=snippet_object)
+    return result_group
 
 
 __all__ = ["parse_snippets_from_source"]

--- a/tests/test_parse_static.py
+++ b/tests/test_parse_static.py
@@ -32,6 +32,8 @@ class TestCaseWithMultilineTags:
         experiment with your content then preview how your webpage will look on Google, Facebook, Twitter and more!">
         <meta property="og:image"
         content="https://metatags.io/assets/meta-tags-16a33a6a8531e519cc0936fbba0ad904e52d35f34a46c97a2c9f6f7dd7d336f2.png">
+        <meta property="og:image:width" content="1200">
+        <meta property="og:image:height" content="630">
         <!-- Twitter -->
         <meta property="twitter:card" content="summary_large_image">
         <meta property="twitter:url" content="https://metatags.io/">
@@ -40,6 +42,8 @@ class TestCaseWithMultilineTags:
         content="With Meta Tags you can edit and experiment with your content then preview
         how your webpage will look on Google, Facebook, Twitter and more!">
         <meta property="twitter:image" content="https://metatags.io/assets/hm-fail.png">
+        <meta property="twitter:image:width" content="1200">
+        <meta property="twitter:image:height" content="630">
     </head>
     <body>
         <a href="#">Kek</a>
@@ -105,6 +109,8 @@ class TestCaseWithMultilineTags:
                     "https://metatags.io/assets/meta-tags-16a33a6a853"
                     "1e519cc0936fbba0ad904e52d35f34a46c97a2c9f6f7dd7d336f2.png"
                 ),
+                image_width="1200",
+                image_height="630",
                 url="https://metatags.io/",
             ),
             twitter=structs.SocialMediaSnippet(
@@ -114,6 +120,8 @@ class TestCaseWithMultilineTags:
                     "        how your webpage will look on Google, Facebook, Twitter and more!"
                 ),
                 image="https://metatags.io/assets/hm-fail.png",
+                image_width="1200",
+                image_height="630",
                 url="https://metatags.io/",
             ),
         )
@@ -127,6 +135,8 @@ class TestCaseWithMultilineTags:
         assert testable_object.twitter.title == "Hi, whatsup kekeke"
         assert testable_object.open_graph.title == ""
         assert testable_object.open_graph.description == ""
+        assert testable_object.twitter.image_width == 0
+        assert testable_object.twitter.image_height == 0
 
 
 def test_general_with_file_fixtures(


### PR DESCRIPTION
## Summary
- simplify snippet tag mapping by using a tuple of allowed meta-tag names
- build each SocialMediaSnippet once per group while preserving immutability

## Testing
- `ruff check meta_tags_parser/snippets.py tests/test_parse_static.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2669cb0448325aaefa90ba9873783