### PR TITLE
Mark structs as immutable dataclasses

### DIFF
--- a/meta_tags_parser/structs.py
+++ b/meta_tags_parser/structs.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 import dataclasses
 import enum
+import typing
 
 
-@dataclasses.dataclass
+@typing.final
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class OneMetaTag:
     """Helper public tag wrapper."""
 
@@ -12,7 +14,8 @@ class OneMetaTag:
     value: str
 
 
-@dataclasses.dataclass
+@typing.final
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class ValuesGroup:
     """Helper inner wrapper."""
 
@@ -20,7 +23,8 @@ class ValuesGroup:
     normalized: str
 
 
-@dataclasses.dataclass
+@typing.final
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class TagsGroup:
     """Return struct."""
 
@@ -31,7 +35,8 @@ class TagsGroup:
     other: list[OneMetaTag] = dataclasses.field(default_factory=list)
 
 
-@dataclasses.dataclass
+@typing.final
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class SocialMediaSnippet:
     """Social media snippet group."""
 
@@ -43,7 +48,8 @@ class SocialMediaSnippet:
     url: str = ""
 
 
-@dataclasses.dataclass
+@typing.final
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class SnippetGroup:
     """Groupping for social media."""
 
@@ -51,6 +57,7 @@ class SnippetGroup:
     twitter: SocialMediaSnippet = dataclasses.field(default_factory=SocialMediaSnippet)
 
 
+@typing.final
 class WhatToParse(enum.IntEnum):
     """Enum for parsing configuration."""
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -1,0 +1,28 @@
+import dataclasses
+
+import pytest
+
+from meta_tags_parser import structs
+
+
+@pytest.mark.parametrize(
+    ("tested_instance", "target_field_name", "new_value"),
+    [
+        (structs.OneMetaTag(name="a", value="b"), "name", "c"),
+        (structs.ValuesGroup(original="d", normalized="e"), "original", "f"),
+        (structs.TagsGroup(), "title", "g"),
+        (
+            structs.SnippetGroup(),
+            "twitter",
+            structs.SocialMediaSnippet(title="h"),
+        ),
+        (structs.SocialMediaSnippet(), "title", "i"),
+    ],
+)
+def test_structs_are_frozen(
+    tested_instance: object,
+    target_field_name: str,
+    new_value: object,
+) -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(tested_instance, target_field_name, new_value)


### PR DESCRIPTION
## Summary
- Make struct dataclasses keyword-only, slotted, frozen and final
- Update parsing logic for immutable data structures
- Add tests checking dataclass immutability
- Use descriptive local names when assembling parsed tag groups

## Testing
- `ruff check .`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a27415665c83259e5515b90c65f19f