### PR TITLE
style: format codebase with ruff

### DIFF
--- a/benchmark/__main__.py
+++ b/benchmark/__main__.py
@@ -1,4 +1,3 @@
-"""This module only for development."""
 import os
 
 from meta_tags_parser.parse import parse_meta_tags_from_source

--- a/benchmark/_payload.py
+++ b/benchmark/_payload.py
@@ -1,4 +1,3 @@
-"""Just a bunch of hardcoded trash-htmls for development purposes."""
 import typing
 
 

--- a/meta_tags_parser/__init__.py
+++ b/meta_tags_parser/__init__.py
@@ -1,5 +1,3 @@
-"""Public interface helper."""
-
 from .parse import parse_meta_tags_from_source
 from .public import (
     parse_snippets_from_url,

--- a/meta_tags_parser/download.py
+++ b/meta_tags_parser/download.py
@@ -1,4 +1,3 @@
-"""Downloader functions."""
 import httpx
 
 

--- a/meta_tags_parser/public.py
+++ b/meta_tags_parser/public.py
@@ -1,5 +1,3 @@
-"""Bunch of public methods."""
-
 from . import download, parse, structs
 from .snippets import parse_snippets_from_source
 

--- a/meta_tags_parser/settings.py
+++ b/meta_tags_parser/settings.py
@@ -1,4 +1,3 @@
-"""Package settings."""
 from __future__ import annotations
 import typing
 
@@ -7,9 +6,7 @@ from . import structs
 
 BASIC_META_TAGS: typing.Final[tuple[str, ...]] = ("title", "description", "keywords", "robots", "viewport")
 SETTINGS_FOR_SOCIAL_MEDIA: typing.Final[
-    dict[
-        typing.Literal[structs.WhatToParse.OPEN_GRAPH, structs.WhatToParse.TWITTER], dict[str, str | tuple[str, ...]]
-    ]
+    dict[typing.Literal[structs.WhatToParse.OPEN_GRAPH, structs.WhatToParse.TWITTER], dict[str, str | tuple[str, ...]]]
 ] = {
     structs.WhatToParse.OPEN_GRAPH: {"prop": ("property",), "prefix": "og:"},
     # weird thing about twitter: it use name and property simultaneously

--- a/meta_tags_parser/snippets.py
+++ b/meta_tags_parser/snippets.py
@@ -1,4 +1,3 @@
-"""Snippets helper functions."""
 import dataclasses
 import typing
 
@@ -16,18 +15,10 @@ def _normalize_dimension(dimension_text: str) -> int:
 _SNIPPET_RULES: typing.Final[
     dict[str, typing.Callable[[structs.SocialMediaSnippet, str], structs.SocialMediaSnippet]]
 ] = {
-    "title": lambda snippet_data, tag_value: dataclasses.replace(
-        snippet_data, title=tag_value
-    ),
-    "description": lambda snippet_data, tag_value: dataclasses.replace(
-        snippet_data, description=tag_value
-    ),
-    "url": lambda snippet_data, tag_value: dataclasses.replace(
-        snippet_data, url=tag_value
-    ),
-    "image": lambda snippet_data, tag_value: dataclasses.replace(
-        snippet_data, image=tag_value
-    ),
+    "title": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, title=tag_value),
+    "description": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, description=tag_value),
+    "url": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, url=tag_value),
+    "image": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, image=tag_value),
     "image:width": lambda snippet_data, tag_value: dataclasses.replace(
         snippet_data, image_width=_normalize_dimension(tag_value)
     ),
@@ -70,4 +61,3 @@ def parse_snippets_from_source(source_code: str) -> structs.SnippetGroup:
 
 
 __all__ = ["parse_snippets_from_source"]
-

--- a/meta_tags_parser/structs.py
+++ b/meta_tags_parser/structs.py
@@ -1,4 +1,3 @@
-"""Main parsing module."""
 from __future__ import annotations
 import dataclasses
 import enum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-"""Fixtures basically."""
 from __future__ import annotations
 import pathlib
 import random
@@ -33,8 +32,7 @@ def provide_fake_meta(faker: Faker) -> tuple[dict[str, str], str]:
     output_buffer: list[str] = []
     control_result: list[tuple[str, str]] = []
     output_buffer.extend(
-        f"""<meta name="{one_name}" content="{faker.text()}">"""
-        for one_name in settings.BASIC_META_TAGS
+        f"""<meta name="{one_name}" content="{faker.text()}">""" for one_name in settings.BASIC_META_TAGS
     )
     for one_name in POSSIBLE_OG_TAGS_VALUES:
         for _ in range(random.randint(1, 5)):
@@ -45,20 +43,12 @@ def provide_fake_meta(faker: Faker) -> tuple[dict[str, str], str]:
                 tag_content = faker.image_url()
             else:
                 tag_content = faker.text()
-            output_buffer.append(
-                f"""<meta property="og:{one_name}" content="{tag_content}">"""
-            )
-            output_buffer.append(
-                f"""<meta name="twitter:{one_name}" content="{tag_content}">"""
-            )
+            output_buffer.append(f"""<meta property="og:{one_name}" content="{tag_content}">""")
+            output_buffer.append(f"""<meta name="twitter:{one_name}" content="{tag_content}">""")
             control_result.append((one_name, tag_content))
     output_buffer.append(f"<title>{faker.text()}</title>")
-    output_buffer.append(
-        f"""<meta name="article:name" content="{faker.text()}">"""
-    )
-    output_buffer.append(
-        f"""<meta name="article:description" content="{faker.text()}">"""
-    )
+    output_buffer.append(f"""<meta name="article:name" content="{faker.text()}">""")
+    output_buffer.append(f"""<meta name="article:description" content="{faker.text()}">""")
     output_buffer.append("""<meta name="bad-tag">""")
     output_buffer.append("""<meta property="another-bad-tag">""")
     return dict(control_result), ("\n \t" * random.randint(1, 5)).join(output_buffer)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,3 @@
-"""Test simple download helpers (stupid tests of course)."""
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock

--- a/tests/test_parse_dynamic.py
+++ b/tests/test_parse_dynamic.py
@@ -1,4 +1,3 @@
-"""Test through public interfaces, e.g. main tests here."""
 from __future__ import annotations
 import typing
 
@@ -11,9 +10,7 @@ EXPECTED_OTHER_TAGS_COUNT: typing.Final = 2
 
 
 @pytest.mark.parametrize("_", range(5))
-def test_parse_from_random_memory(
-    provide_fake_meta: tuple[dict[str, str], str], _: int
-) -> None:
+def test_parse_from_random_memory(provide_fake_meta: tuple[dict[str, str], str], _: int) -> None:
     """Random based tests of main parsing."""
     result: structs.TagsGroup = parse_meta_tags_from_source(provide_fake_meta[1])
     for one_group in (result.open_graph, result.twitter):

--- a/tests/test_parse_static.py
+++ b/tests/test_parse_static.py
@@ -1,4 +1,3 @@
-"""Test through public interfaces, e.g. main tests here."""
 from __future__ import annotations
 import typing
 

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,4 +1,3 @@
-"""Simple public interface tests."""
 from __future__ import annotations
 
 import pytest
@@ -6,9 +5,7 @@ import pytest
 from meta_tags_parser import public
 
 
-def test_public_download(
-    monkeypatch: pytest.MonkeyPatch, provide_fake_meta: tuple[dict[str, str], str]
-) -> None:
+def test_public_download(monkeypatch: pytest.MonkeyPatch, provide_fake_meta: tuple[dict[str, str], str]) -> None:
     """Test download via public API."""
 
     # pylint: disable=too-few-public-methods


### PR DESCRIPTION
## Summary
- format project files using ruff to align with codestyle
- remove module-level docstrings to match codestyle

## Testing
- `ruff format .`
- `ruff check .`
- `mypy --strict meta_tags_parser tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3ce11c00083258318b1abb4e25363