### PR TITLE
Refactor dimension parsing and improve coverage

### DIFF
--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -1,0 +1,15 @@
+import typing
+
+import pytest
+
+from meta_tags_parser import parse_snippets_from_source
+
+
+@pytest.mark.parametrize(
+    ("dimension_text", "expected_width"),
+    [("123", 123), ("abc", 0)],
+)
+def test_parse_image_width(dimension_text: str, expected_width: int) -> None:
+    html_text: typing.Final = f'<meta property="twitter:image:width" content="{dimension_text}">'
+    parsed_snippets: typing.Final = parse_snippets_from_source(html_text)
+    assert parsed_snippets.twitter.image_width == expected_width


### PR DESCRIPTION
## Summary
- refactor snippet dimension parsing helper
- add parameterized tests for parsing snippet image dimensions
- enforce immutability with `typing.Final` and remove obsolete comments

## Testing
- `ruff check . --statistics`
- `mypy meta_tags_parser tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4faf006ec8325bf720255e45c1b94