### PR TITLE
feat: enforce immutability

### DIFF
--- a/benchmark/__main__.py
+++ b/benchmark/__main__.py
@@ -1,13 +1,15 @@
 import os
+import typing
 
+from meta_tags_parser import structs
 from meta_tags_parser.parse import parse_meta_tags_from_source
 
 from ._payload import PAYLOAD_DATA
 
 
-def test_my_code():
+def test_my_code() -> None:
     """Just stupid speed test."""
-    result = parse_meta_tags_from_source(PAYLOAD_DATA)
+    result: typing.Final[structs.TagsGroup] = parse_meta_tags_from_source(PAYLOAD_DATA)
     for one_attr in [one_attr for one_attr in dir(result) if not one_attr.startswith("_")]:
         print(one_attr, getattr(result, one_attr))
 
@@ -16,6 +18,3 @@ if __name__ == "__main__":
     import timeit
 
     print(timeit.timeit("test_my_code()", globals=locals(), number=int(os.getenv("COUNTS", "1"))))
-
-
-__all__ = ["test_my_code"]

--- a/meta_tags_parser/__init__.py
+++ b/meta_tags_parser/__init__.py
@@ -1,18 +1,12 @@
-from .parse import parse_meta_tags_from_source
-from .public import (
-    parse_snippets_from_url,
-    parse_snippets_from_url_async,
-    parse_tags_from_url,
-    parse_tags_from_url_async,
-)
-from .snippets import parse_snippets_from_source
+from . import parse as parse
+from . import public as public
+from . import snippets as snippets
+from . import structs as structs
 
 
-__all__ = [
-    "parse_meta_tags_from_source",
-    "parse_snippets_from_source",
-    "parse_snippets_from_url",
-    "parse_snippets_from_url_async",
-    "parse_tags_from_url",
-    "parse_tags_from_url_async",
-]
+parse_meta_tags_from_source = parse.parse_meta_tags_from_source
+parse_snippets_from_source = snippets.parse_snippets_from_source
+parse_snippets_from_url = public.parse_snippets_from_url
+parse_snippets_from_url_async = public.parse_snippets_from_url_async
+parse_tags_from_url = public.parse_tags_from_url
+parse_tags_from_url_async = public.parse_tags_from_url_async

--- a/meta_tags_parser/download.py
+++ b/meta_tags_parser/download.py
@@ -1,3 +1,5 @@
+import typing
+
 import httpx
 
 
@@ -9,8 +11,7 @@ def download_page_sync(uri_of_page: str) -> str:
 async def download_page_async(uri_of_page: str) -> str:
     """Download page asynchronously."""
     async with httpx.AsyncClient() as client:
-        request_obj: httpx.Response = await client.get(uri_of_page)
+        request_obj: typing.Final[httpx.Response] = await client.get(uri_of_page)
         return request_obj.text
 
 
-__all__ = ["download_page_async", "download_page_sync"]

--- a/meta_tags_parser/public.py
+++ b/meta_tags_parser/public.py
@@ -22,9 +22,3 @@ async def parse_snippets_from_url_async(web_url: str) -> structs.SnippetGroup:
     return parse_snippets_from_source(await download.download_page_async(web_url))
 
 
-__all__ = [
-    "parse_snippets_from_url",
-    "parse_snippets_from_url_async",
-    "parse_tags_from_url",
-    "parse_tags_from_url_async",
-]

--- a/meta_tags_parser/settings.py
+++ b/meta_tags_parser/settings.py
@@ -1,18 +1,29 @@
-from __future__ import annotations
+import types
 import typing
 
 from . import structs
 
 
-BASIC_META_TAGS: typing.Final[tuple[str, ...]] = ("title", "description", "keywords", "robots", "viewport")
+BASIC_META_TAGS: typing.Final[tuple[str, ...]] = (
+    "title",
+    "description",
+    "keywords",
+    "robots",
+    "viewport",
+)
 SETTINGS_FOR_SOCIAL_MEDIA: typing.Final[
-    dict[typing.Literal[structs.WhatToParse.OPEN_GRAPH, structs.WhatToParse.TWITTER], dict[str, str | tuple[str, ...]]]
-] = {
-    structs.WhatToParse.OPEN_GRAPH: {"prop": ("property",), "prefix": "og:"},
-    # weird thing about twitter: it use name and property simultaneously
-    # i mean name is old format, property is new, but all currently accepted as i see at the moment
-    structs.WhatToParse.TWITTER: {"prop": ("name", "property"), "prefix": "twitter:"},
-}
+    typing.Mapping[
+        typing.Literal[structs.WhatToParse.OPEN_GRAPH, structs.WhatToParse.TWITTER],
+        typing.Mapping[str, str | tuple[str, ...]],
+    ]
+] = types.MappingProxyType(
+    {
+        structs.WhatToParse.OPEN_GRAPH: types.MappingProxyType({"prop": ("property",), "prefix": "og:"}),
+        # weird thing about twitter: it use name and property simultaneously
+        # i mean name is old format, property is new, but all currently accepted as i see at the moment
+        structs.WhatToParse.TWITTER: types.MappingProxyType({"prop": ("name", "property"), "prefix": "twitter:"}),
+    }
+)
 DEFAULT_PARSE_GROUP: typing.Final[tuple[structs.WhatToParse, ...]] = (
     structs.WhatToParse.TITLE,
     structs.WhatToParse.BASIC,

--- a/meta_tags_parser/snippets.py
+++ b/meta_tags_parser/snippets.py
@@ -1,4 +1,5 @@
 import dataclasses
+import types
 import typing
 
 from . import structs
@@ -13,25 +14,31 @@ def _normalize_dimension(dimension_text: str) -> int:
 
 
 _SNIPPET_RULES: typing.Final[
-    dict[str, typing.Callable[[structs.SocialMediaSnippet, str], structs.SocialMediaSnippet]]
-] = {
-    "title": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, title=tag_value),
-    "description": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, description=tag_value),
-    "url": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, url=tag_value),
-    "image": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, image=tag_value),
-    "image:width": lambda snippet_data, tag_value: dataclasses.replace(
-        snippet_data, image_width=_normalize_dimension(tag_value)
-    ),
-    "image:height": lambda snippet_data, tag_value: dataclasses.replace(
-        snippet_data, image_height=_normalize_dimension(tag_value)
-    ),
-}
+    typing.Mapping[
+        str, typing.Callable[[structs.SocialMediaSnippet, str], structs.SocialMediaSnippet]
+    ]
+] = types.MappingProxyType(
+    {
+        "title": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, title=tag_value),
+        "description": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, description=tag_value),
+        "url": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, url=tag_value),
+        "image": lambda snippet_data, tag_value: dataclasses.replace(snippet_data, image=tag_value),
+        "image:width": lambda snippet_data, tag_value: dataclasses.replace(
+            snippet_data, image_width=_normalize_dimension(tag_value)
+        ),
+        "image:height": lambda snippet_data, tag_value: dataclasses.replace(
+            snippet_data, image_height=_normalize_dimension(tag_value)
+        ),
+    }
+)
 
 
 def _merge_snippet_tag(
     snippet_object: structs.SocialMediaSnippet, one_meta_tag: structs.OneMetaTag
 ) -> structs.SocialMediaSnippet:
-    rule = _SNIPPET_RULES.get(one_meta_tag.name)
+    rule: typing.Final[
+        typing.Callable[[structs.SocialMediaSnippet, str], structs.SocialMediaSnippet] | None
+    ] = _SNIPPET_RULES.get(one_meta_tag.name)
     if rule is None:
         return snippet_object
     return rule(snippet_object, one_meta_tag.value)
@@ -60,4 +67,3 @@ def parse_snippets_from_source(source_code: str) -> structs.SnippetGroup:
     return result_group
 
 
-__all__ = ["parse_snippets_from_source"]

--- a/meta_tags_parser/structs.py
+++ b/meta_tags_parser/structs.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import dataclasses
 import enum
 import typing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,11 @@
-from __future__ import annotations
 import pathlib
 import random
 import typing
 
 import pytest
+from faker import Faker
 
 from meta_tags_parser import settings
-
-
-if typing.TYPE_CHECKING:
-    from faker import Faker
 
 
 FIXTURES_DIR: typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / "html_fixtures"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,14 +1,9 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+from faker import Faker
 
 from meta_tags_parser import download
-
-
-if TYPE_CHECKING:
-    from faker import Faker
 
 
 @pytest.mark.asyncio

--- a/tests/test_parse_dynamic.py
+++ b/tests/test_parse_dynamic.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import typing
 
 import pytest

--- a/tests/test_parse_static.py
+++ b/tests/test_parse_static.py
@@ -1,11 +1,7 @@
-from __future__ import annotations
+import pathlib
 import typing
 
 from meta_tags_parser import parse_meta_tags_from_source, parse_snippets_from_source, structs
-
-
-if typing.TYPE_CHECKING:
-    import pathlib
 
 
 EXPECTED_TWITTER_TAGS_COUNT: typing.Final = 4

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 
 from meta_tags_parser import public


### PR DESCRIPTION
## Summary
- remove `__future__` annotations imports and `__all__` declarations
- re-export helpers via direct assignments to keep package API

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc4384088325ac0f753f3990c1b3