### PR TITLE
Reject non-ASCII digits when parsing dimensions

### DIFF
--- a/meta_tags_parser/snippets.py
+++ b/meta_tags_parser/snippets.py
@@ -6,9 +6,12 @@ from .parse import parse_meta_tags_from_source
 
 
 def _parse_dimension(dimension_text: str) -> int:
-    if dimension_text.isdigit():
-        return int(dimension_text)
-    return 0
+    cleaned_text: typing.Final[str] = dimension_text.strip()
+    if not cleaned_text:
+        return 0
+    if not cleaned_text.isascii() or not cleaned_text.isdigit():
+        return 0
+    return int(cleaned_text)
 
 
 _SNIPPET_RULES: typing.Final[
@@ -30,9 +33,9 @@ _SNIPPET_RULES: typing.Final[
 def _merge_snippet_tag(
     snippet_object: structs.SocialMediaSnippet, one_meta_tag: structs.OneMetaTag
 ) -> structs.SocialMediaSnippet:
-    rule: typing.Final[
-        typing.Callable[[structs.SocialMediaSnippet, str], structs.SocialMediaSnippet] | None
-    ] = _SNIPPET_RULES.get(one_meta_tag.name)
+    rule: typing.Final[typing.Callable[[structs.SocialMediaSnippet, str], structs.SocialMediaSnippet] | None] = (
+        _SNIPPET_RULES.get(one_meta_tag.name)
+    )
     if rule is None:
         return snippet_object
     return rule(snippet_object, one_meta_tag.value)

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -7,7 +7,12 @@ from meta_tags_parser import parse_snippets_from_source
 
 @pytest.mark.parametrize(
     ("dimension_text", "expected_width"),
-    [("123", 123), ("abc", 0)],
+    [
+        ("123", 123),
+        ("abc", 0),
+        ("\u0665", 0),
+        ("²", 0),
+    ],
 )
 def test_parse_image_width(dimension_text: str, expected_width: int) -> None:
     html_text: typing.Final = f'<meta property="twitter:image:width" content="{dimension_text}">'


### PR DESCRIPTION
## Summary
- consider only ASCII digits when converting dimension tags to integers
- test that Unicode digits are treated as invalid

## Testing
- `uv run ruff check .`
- `uv run mypy --strict meta_tags_parser tests`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5028797f08325ae3f20d24f2143ee