### PR TITLE
Use ContextVar for global options

### DIFF
--- a/meta_tags_parser/download.py
+++ b/meta_tags_parser/download.py
@@ -1,11 +1,14 @@
+import typing
+
 import httpx
 
 
 def download_page_sync(uri_of_page: str) -> str:
-    return httpx.get(uri_of_page).text
+    response_obj: typing.Final[httpx.Response] = httpx.get(uri_of_page)
+    return response_obj.text
 
 
 async def download_page_async(uri_of_page: str) -> str:
     async with httpx.AsyncClient() as client:
-        request_obj: typing.Final[httpx.Response] = await client.get(uri_of_page)
-        return request_obj.text
+        response_obj: typing.Final[httpx.Response] = await client.get(uri_of_page)
+        return response_obj.text

--- a/meta_tags_parser/parse.py
+++ b/meta_tags_parser/parse.py
@@ -1,3 +1,4 @@
+import contextvars
 import typing
 
 from selectolax.lexbor import LexborHTMLParser, LexborNode
@@ -7,14 +8,13 @@ from . import settings, structs
 
 if typing.TYPE_CHECKING:
     from collections.abc import KeysView
-
-
-_GLOBAL_OPTIONS_HOLDER: dict[str, structs.PackageOptions] = {"options": structs.PackageOptions()}
+_GLOBAL_OPTIONS_HOLDER: typing.Final[contextvars.ContextVar[structs.PackageOptions]] = contextvars.ContextVar("options")
+_GLOBAL_OPTIONS_HOLDER.set(structs.PackageOptions())
 
 
 def set_config_for_metatags(new_options: structs.PackageOptions) -> None:
     """Override default package options."""
-    _GLOBAL_OPTIONS_HOLDER["options"] = new_options
+    _GLOBAL_OPTIONS_HOLDER.set(new_options)
 
 
 def _slice_html_for_meta(  # noqa: PLR0913
@@ -151,7 +151,7 @@ def parse_meta_tags_from_source(
     else:
         normalized_source = source_code
 
-    active_options: structs.PackageOptions = options or _GLOBAL_OPTIONS_HOLDER["options"]
+    active_options: structs.PackageOptions = options or _GLOBAL_OPTIONS_HOLDER.get()
     sliced_source: str = _slice_html_for_meta(
         normalized_source,
         optimize_input=active_options.optimize_input,


### PR DESCRIPTION
## Summary
- Replace mutable global options dict with `ContextVar` to support context-specific configuration
- Initialize and access package options via the new context variable
- Import `typing` in download helpers and return typed `httpx.Response` text values

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8cfd7605c83259ca9fccca173327c