### PR TITLE
Add coverage for global settings and snippet dimensions

### DIFF
--- a/tests/test_parse_settings.py
+++ b/tests/test_parse_settings.py
@@ -1,0 +1,33 @@
+import typing
+
+from meta_tags_parser import parse_meta_tags_from_source, set_settings_for_meta_tags, structs
+
+
+def test_set_settings_for_meta_tags_overrides_defaults() -> None:
+    html_text: typing.Final[str] = (
+        "<html><head>"
+        "<title>Site Title</title>"
+        '<meta name="description" content="Example description">'
+        '<meta property="og:title" content="OG Title">'
+        '<meta name="twitter:title" content="Twitter Title">'
+        "</head></html>"
+    )
+    restrictive_settings: typing.Final[structs.SettingsFromUser] = structs.SettingsFromUser(
+        what_to_parse=(structs.WhatToParse.TITLE,),
+    )
+    set_settings_for_meta_tags(restrictive_settings)
+    try:
+        limited_result: typing.Final[structs.TagsGroup] = parse_meta_tags_from_source(html_text)
+    finally:
+        set_settings_for_meta_tags(structs.DEFAULT_SETTINGS_FROM_USER)
+
+    assert limited_result.title == "Site Title"
+    assert not limited_result.basic
+    assert not limited_result.open_graph
+    assert not limited_result.twitter
+    assert not limited_result.other
+
+    restored_result: typing.Final[structs.TagsGroup] = parse_meta_tags_from_source(html_text)
+    assert restored_result.basic
+    assert restored_result.open_graph
+    assert restored_result.twitter

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -5,11 +5,13 @@ import hypothesis.strategies as st
 import pytest
 
 from meta_tags_parser import parse_snippets_from_source
+from meta_tags_parser.snippets import _parse_dimension
 
 
 @pytest.mark.parametrize(
     ("dimension_text", "expected_width"),
     [
+        ("", 0),
         ("123", 123),
         ("abc", 0),
         ("\u0665", 0),
@@ -34,8 +36,12 @@ UNICODE_DIGITS: typing.Final = st.characters(whitelist_categories=["Nd"])
     )
 )
 def test_parse_image_width_property(dimension_text: str) -> None:
-    html_text: typing.Final = f'<meta property="twitter:image:width" content="{dimension_text}">'
+    html_text: typing.Final = f'<meta property="twitter:image:width" content="{dimension_text}">' 
     parsed_snippets: typing.Final = parse_snippets_from_source(html_text)
     cleaned_text: typing.Final[str] = dimension_text.strip()
     expected_width: typing.Final[int] = int(cleaned_text) if cleaned_text.isascii() and cleaned_text.isdigit() else 0
     assert parsed_snippets.twitter.image_width == expected_width
+
+
+def test_parse_dimension_empty_text_returns_zero() -> None:
+    assert _parse_dimension("   ") == 0


### PR DESCRIPTION
### **User description**
## Summary
- add a regression test confirming `set_settings_for_meta_tags` updates the package-wide parsing defaults
- extend snippet parsing tests to cover empty dimension values via the private helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc77ae95e48325a7f1ac441b99c139


___

### **PR Type**
Tests


___

### **Description**
- Add regression test for global settings override functionality

- Extend snippet dimension parsing tests with empty values

- Test private helper function for dimension parsing

- Ensure proper settings restoration after test execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global Settings Test"] --> B["Override Defaults"]
  B --> C["Parse with Restrictions"]
  C --> D["Restore Settings"]
  E["Snippet Tests"] --> F["Empty Dimension Values"]
  F --> G["Private Helper Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_parse_settings.py</strong><dd><code>Add global settings override test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_parse_settings.py

<ul><li>Add new test file for global settings functionality<br> <li> Test <code>set_settings_for_meta_tags</code> override behavior<br> <li> Verify restrictive parsing settings work correctly<br> <li> Ensure proper settings restoration after test</ul>


</details>


  </td>
  <td><a href="https://github.com/xfenix/meta-tags-parser/pull/34/files#diff-60e7656f8d974f4b1c93366f210b0d79302664bc65fd4308ee0a61d7b2e55bb5">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_snippets.py</strong><dd><code>Extend snippet dimension parsing tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_snippets.py

<ul><li>Add empty string test case to dimension parsing<br> <li> Import private <code>_parse_dimension</code> helper function<br> <li> Add dedicated test for empty dimension text handling<br> <li> Extend property-based testing coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/xfenix/meta-tags-parser/pull/34/files#diff-c7247010569088b1eb349d38d8ad8c79c520603d86f51dc671231ca9ca2ec95d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

