### PR TITLE
Fix trailing whitespace in tests

### DIFF
--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -36,7 +36,7 @@ UNICODE_DIGITS: typing.Final = st.characters(whitelist_categories=["Nd"])
     )
 )
 def test_parse_image_width_property(dimension_text: str) -> None:
-    html_text: typing.Final = f'<meta property="twitter:image:width" content="{dimension_text}">' 
+    html_text: typing.Final = f'<meta property="twitter:image:width" content="{dimension_text}">'
     parsed_snippets: typing.Final = parse_snippets_from_source(html_text)
     cleaned_text: typing.Final[str] = dimension_text.strip()
     expected_width: typing.Final[int] = int(cleaned_text) if cleaned_text.isascii() and cleaned_text.isdigit() else 0


### PR DESCRIPTION
### **User description**
## Summary
- remove trailing whitespace from the twitter image width test to satisfy Ruff

## Testing
- uv run ruff check --no-fix .

------
https://chatgpt.com/codex/tasks/task_e_68cc7985b82083259676c281a595af27


___

### **PR Type**
Other


___

### **Description**
- Remove trailing whitespace from test file to satisfy linting requirements


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_snippets.py</strong><dd><code>Remove trailing whitespace from test function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_snippets.py

<ul><li>Remove trailing whitespace from line 34 in <br><code>test_parse_image_width_property</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/xfenix/meta-tags-parser/pull/35/files#diff-c7247010569088b1eb349d38d8ad8c79c520603d86f51dc671231ca9ca2ec95d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

